### PR TITLE
Keep recording even if the user is 'idle'

### DIFF
--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -67,10 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func updateButton() {
         var idle: Bool
 
-        if (self.sinceUserActivity() > userIdleSeconds) {
-            timerStart = Date()
-            idle = true
-        } else if (CGDisplayIsAsleep(CGMainDisplayID()) == 1) {
+        if (CGDisplayIsAsleep(CGMainDisplayID()) == 1) {
             timerStart = Date()
             idle = true
         } else {


### PR DESCRIPTION
The user may have been watching some movie or youtube video and was not interacting with the computer for some time. Even though this removes the edge case of desktop computers, I think the widget should track how much the computer has been turned on. (or allow some customization)